### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Import \<Azot/Azot.h\> in your bridging header.
 
 The SDK does not generate videos on simulator.
 
-If you are running from XCode do not stop the app, press the "home" button in order for data to be uploaded.
+If you are running from Xcode do not stop the app, press the "home" button in order for data to be uploaded.
 
 ##Confidentiality
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
